### PR TITLE
2 post translations from locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-    "name": "ts-translate",
+    "name": "bilingual-translate",
     "private": false,
-    "version": "0.0.3",
+    "version": "0.0.0",
     "type": "commonjs",
     "types": "build/types/config.d.ts",
     "main": "build/get-translated.js",
+    "homepage": "https://bilingual.vuvusha.com",
     "bin": {
         "get-translated": "build/get-translated.js",
         "push-locales": "build/push-locales.js"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
     "name": "ts-translate",
     "private": false,
-    "version": "0.0.2",
+    "version": "0.0.3",
     "type": "commonjs",
     "types": "build/types/config.d.ts",
-    "main": "build/sync-local.js",
+    "main": "build/get-translated.js",
     "bin": {
-        "sync-locale": "build/sync-local.js"
+        "get-translated": "build/get-translated.js",
+        "push-locales": "build/push-locales.js"
     },
     "author": {
         "name": "Subash Rijal",
@@ -15,11 +16,12 @@
     },
     "scripts": {
         "build": "tsc",
-        "sync-locale": "node build/sync-local.js",
+        "get-translated": "node build/get-translated.js",
+        "push-locales": "node build/push-locales",
         "test": "jest",
         "prepare": "husky install",
-        "lint": "eslint \"*/**/*.{ts,js,json}\"",
-        "lint:fix": "eslint \"*/**/*.{ts,js,json}\" --fix",
+        "lint": "eslint \"*/**/*.{ts,js}\"",
+        "lint:fix": "eslint \"*/**/*.{ts,js}\" --fix",
         "copy-typescript-definitions": "copyfiles -u 1 \"src/**/*.d.ts\" build",
         "prepublishOnly": " npm run lint && npm run test && npm run build"
     },

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,0 +1,37 @@
+import { ConfigType } from "../types/config";
+import { ApiClient } from "../utils/api";
+import { FileHandler } from "../utils/file-handler";
+
+export class Command {
+	protected apiClient: ApiClient;
+	protected fileHandler: FileHandler;
+  
+	constructor(protected config: ConfigType) {
+		this.validateKeys(config);
+		this.apiClient = new ApiClient(
+      config.BILINGUAL_API_KEY!,
+      config.BILINGUAL_API_URL!,
+		);
+		this.fileHandler = new FileHandler(config.LOCALE_BASE_PATH!);
+	}
+	/**
+   * Validates the configuration object.
+   * @param config - The configuration object containing various properties.
+   * @throws {Error} - Throws an error if any of the required properties are missing in the `config` object.
+   */
+	private validateKeys(config: ConfigType) {
+		const requiredProperties: (keyof ConfigType)[] = [
+			"BILINGUAL_API_KEY",
+			"LOCALE_BASE_PATH",
+			"BILINGUAL_API_URL",
+			"GROUPED",
+			"BILINGUAL_DEFAULT_FILE_NAME",
+		];
+
+		for (const property of requiredProperties) {
+			if (!config[property]) {
+				throw new Error(`${property} is not set in env`);
+			}
+		}
+	}
+}

--- a/src/commands/get-text.ts
+++ b/src/commands/get-text.ts
@@ -1,55 +1,20 @@
 import { BilingualError } from "../errors/BilingualError";
-import { ConfigType } from "../types/config";
-import { ApiClient } from "../utils/api";
-import { FileHandler } from "../utils/file-handler";
+import { Command } from "./command";
 
-export class GetTexts {
-	private apiClient: ApiClient;
-	private fileHandler: FileHandler;
-
-	constructor(protected config: ConfigType) {
-		this.validateKeys(config);
-		this.apiClient = new ApiClient(
-      config.BILINGUAL_API_KEY!,
-      config.BILINGUAL_API_URL!,
-		);
-		this.fileHandler = new FileHandler(config.LOCALE_BASE_PATH!);
-	}
-
-	/**
-   * Validates the configuration object.
-   * @param config - The configuration object containing various properties.
-   * @throws {Error} - Throws an error if any of the required properties are missing in the `config` object.
-   */
-	private validateKeys(config: ConfigType) {
-		const requiredProperties: (keyof ConfigType)[] = [
-			"BILINGUAL_API_KEY",
-			"LOCALE_BASE_PATH",
-			"BILINGUAL_API_URL",
-			"GROUPED",
-			"BILINGUAL_DEFAULT_FILE_NAME",
-		];
-
-		for (const property of requiredProperties) {
-			if (!config[property]) {
-				throw new Error(`${property} is not set in env`);
-			}
-		}
-	}
-
-	public async initiate() {
+export class GetTexts extends Command {
+	public async execute() {
 		try {
 			const languages = await this.apiClient.getProjectLanguages();
 
 			languages.map(async (language) => {
 				const strings = await this.apiClient.getLanguageStrings(
-					language.short_code,
+					language.short_code
 				);
 
 				this.fileHandler.writeFile(language.short_code, strings);
 			});
 		} catch (error) {
-			if(error instanceof BilingualError){
+			if (error instanceof BilingualError) {
 				console.error(error.message, error.toJSON());
 				return;
 			}

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -4,9 +4,15 @@ envConfig();
 
 import { GetTexts } from "./get-text";
 import { config } from "../config/config";
+import { PushTexts } from "./push-text";
 
-const client = new GetTexts(config);
+const getText = new GetTexts(config);
+const pushText = new PushTexts(config);
 
 export const syncLocale = async () => {
-	await client.initiate().catch((e) => console.log(e));
+	await getText.execute().catch((e) => console.error(e));
+};
+
+export const pushLocales = async () => {
+	await pushText.execute().catch((e) => console.error(e));
 };

--- a/src/commands/push-text.ts
+++ b/src/commands/push-text.ts
@@ -1,0 +1,32 @@
+import { getLocaleCodeMapFromServer } from "../config/config";
+import { Command } from "./command";
+
+export class PushTexts extends Command {
+
+	public async execute(): Promise<void> {
+		console.info("🚀 ~ PushTexts ~ Reading current locales \n");
+		const localeLanguageCodes =  this.fileHandler.getCurrentLanguageCodes();
+		
+		console.info("\n 🚀 ~ PushTexts ~ Getting Project info");
+		const project = await this.apiClient.getProject();
+		const baseLanguage = project.data.base_language;
+
+		console.info(`🚀 ~ PushTexts ~ Getting local files for language ${baseLanguage}\n`);
+
+		const getMappedBaseLanguage = getLocaleCodeMapFromServer(baseLanguage);
+
+		if(!localeLanguageCodes.includes(getMappedBaseLanguage)){
+			throw new Error(`🚀 ~ PushTexts ~Base language ${getMappedBaseLanguage} is not in the current locales\n`);
+		}
+
+		console.info("🚀 ~ PushTexts ~ locale files of base language");
+		const baseLanguageStrings = this.fileHandler.getStringsFromLocales(baseLanguage);
+		// console.log("🚀 ~ PushTexts ~ execute ~ baseLanguageStrings:");
+		console.info("🚀 ~ PushTexts ~ Sending strings to the server.\n");
+		const response =  await this.apiClient.pushLanguageString(baseLanguage, baseLanguageStrings);
+		console.info("🚀 ~ PushTexts ~ Completed pushing the strings.\n", response, "\n");
+
+		process.exit(1);
+        
+	}
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -18,7 +18,7 @@ export function getLocaleCodeMapFromServer(langCode: string){
 
 export const config: ConfigType = {
 	BILINGUAL_API_KEY: process.env.BILINGUAL_API_KEY,
-	LOCALE_BASE_PATH: process.env.LOCALE_BASE_PATH ?? "/locales",
+	LOCALE_BASE_PATH: process.env.LOCALE_BASE_PATH ?? "locales",
 	BILINGUAL_API_URL:
     process.env.BILINGUAL_API_URL ?? "https://bilingualapp.vuvusha.com",
 	GROUPED: process.env.GROUPED

--- a/src/get-translated.ts
+++ b/src/get-translated.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { syncLocale } from "./commands/main";
+
+syncLocale();

--- a/src/push-locales.ts
+++ b/src/push-locales.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { pushLocales } from "./commands/main";
+
+pushLocales();

--- a/src/sync-local.ts
+++ b/src/sync-local.ts
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import { syncLocale } from "./commands/main";
-
-syncLocale();

--- a/src/types/get-text.d.ts
+++ b/src/types/get-text.d.ts
@@ -21,3 +21,16 @@ export type SingleStringType = {
 };
 
 export type SingleStringGroup = Record<string, SingleStringType[]>;
+
+
+export type ProjectType = {
+  id: number;
+  name: string;
+  base_language: string;
+  slug: string;
+}
+
+export type ResponseType<T> = {
+  data: T;
+  message: string;
+}


### PR DESCRIPTION
### This PR completes sync base language directory to the server from locale.

Run: 
`npx push-locales`

The command do following things: 

1. Scan the base language directory 
2. get all the json from all of the files. 
3. Each file will be assumed as a single group/page
4. If files has nested json. the key of the string will be concatinated with `.`
5. When you the translated strings, package itself do reverse and write on the same format, so feel free to use nested json.